### PR TITLE
chore: don't lint PR on merge group checks

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -13,6 +13,7 @@ jobs:
   validate:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This causes a workflow failure that is logged and/or blocks the merge.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
