### PR TITLE
chore: add periodic job to check key validity

### DIFF
--- a/.github/workflows/check-key-validity.yml
+++ b/.github/workflows/check-key-validity.yml
@@ -1,0 +1,23 @@
+
+name: Check GPG Key Expiry
+
+on:
+  schedule:
+    # Run every Monday at 9:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch: {} # Allow manual trigger
+
+jobs:
+  check-gpg-keys:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install GPG
+        run: sudo apt-get install -y gnupg
+
+      - name: Check GPG key expiry dates
+        run: |
+          ./scripts/check-key-expiry.sh

--- a/scripts/check-key-expiry.sh
+++ b/scripts/check-key-expiry.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+date=date
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # Use GNU date on Mac (must be separately installed using Homebrew)
+  date=gdate
+fi
+
+# Get current date in seconds since epoch
+current_date=$($date +%s)
+# Date 30 days from now in seconds since epoch
+expiry_threshold=$($date -d "+30 days" +%s)
+
+# Check each key in the directory
+exitcode=0
+for key_file in superchain/gpg/*.asc; do
+  # Get key expiry date (UNIX timestamp)
+  expiry_date=$(gpg --with-colons --show-keys $key_file | grep pub: | cut -d: -f7)
+
+  # If key has expiry date
+  if [ ! -z "$expiry_date" ]; then
+    echo "$key_file will expire on $($date -I -d "@$expiry_date")"
+    if [ $expiry_date -lt $expiry_threshold ]; then
+      echo "::error::GPG key $key_file will expire soon (on $($date -I -d "@$expiry_date"))"
+      exitcode=1
+    fi
+  else
+    echo "$key_file has no expiry date"
+  fi
+done
+
+exit $exitcode


### PR DESCRIPTION
Every Monday we'll check whether the keys in this repo are about to expire and throw an error if they do.

Current state:

```
superchain/gpg/corretto.asc will expire on 2029-12-02
superchain/gpg/docker.asc has no expiry date
superchain/gpg/mono.asc has no expiry date
superchain/gpg/nodesource.asc has no expiry date
superchain/gpg/yarn.asc has no expiry date
```

Not a lot of risk of anything bad happening, but it seems good practice to have this in place anyway.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
