### PR TITLE
fix: bump go to 1.23.0

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -27,7 +27,7 @@ if [[ "${PLATFORM}" == "x86_64" ]]; then
 fi
 
 # Now on to building the image
-${DOCKER:-docker} build                                                         \
+${DOCKER:-docker} buildx build                                                  \
   --target superchain                                                           \
   --build-arg BUILDPLATFORM=linux/${PLATFORM}                                   \
   --build-arg TARGETPLATFORM=linux/${PLATFORM}                                  \
@@ -35,6 +35,7 @@ ${DOCKER:-docker} build                                                         
   --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')                  \
   --build-arg REGISTRY="docker.io/library"                                      \
   --build-arg COMMIT_ID=${COMMIT_ID}                                            \
+  --progress=plain                                                              \
   -t "public.ecr.aws/jsii/superchain:1-${DEBIAN_VERSION:-bookworm}-local"       \
   -f superchain/Dockerfile                                                      \
   superchain

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ########################################################################################################################
 # Introduction
 ########################################################################################################################
@@ -336,19 +338,7 @@ RUN RUST_DOCS="${RUSTUP_HOME}/toolchains/$(rustup show active-toolchain | cut -d
   && echo "------------------------------------ LICENSE ------------------------------------" >> /NOTICE                \
   && cat ${M2_HOME}/LICENSE >> /NOTICE                                                                                  \
   && echo "################################################################################" >> /NOTICE                 \
-  && echo "cargo:" >> /NOTICE                                                                                           \
-  && echo "" >> /NOTICE                                                                                                 \
-  && echo "------------------------------------ LICENSE (APACHE) ------------------------------------" >> /NOTICE       \
-  && cat ${RUST_DOCS}/cargo/LICENSE-APACHE >> /NOTICE                                                                   \
-  && echo "" >> /NOTICE                                                                                                 \
-  && echo "------------------------------------ LICENSE (MIT) ------------------------------------" >> /NOTICE          \
-  && cat ${RUST_DOCS}/cargo/LICENSE-MIT >> /NOTICE                                                                      \
-  && echo "" >> /NOTICE                                                                                                 \
-  && echo "------------------------------------ THIRD-PARTY LICENSES ------------------------------------" >> /NOTICE   \
-  && cat ${RUST_DOCS}/cargo/LICENSE-THIRD-PARTY >> /NOTICE                                                              \
-  && echo "################################################################################" >> /NOTICE                 \
-  && echo "rust:" >> /NOTICE                                                                                            \
-  && cat ${RUST_DOCS}/rust/COPYRIGHT >> /NOTICE                                                                         \
+  && (cd $RUST_DOCS && find . -type f -name 'LICENSE*' -or -name 'COPYRIGHT*' -exec echo {} \; -exec cat {} \;) >> /NOTICE \
   && echo "################################################################################" >> /NOTICE                 \
   && echo "rustup:" >> /NOTICE                                                                                          \
   && echo "" >> /NOTICE                                                                                                 \


### PR DESCRIPTION
Our jsii go builds are now failing with:

```
invalid go version '1.23.0': must match format 1.23
```

There are 2 things going on:

- Go has started using 3 component version numbers, and go 1.21.0 is the first one to understand that (old versions will complain 3 components is not allowed).
- Second, our dependency `x/tools` has started requiring 1.23.0.

1.22 has been end of life for 4 months (and we used to be on 1.18). It seems alright to move to the lowest supported version.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
