### PR TITLE
fix: bump go to 1.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Any other tags should be *considered* deprecated or in the case of `nightly` ima
 | `Javascript` | see [Current image tags](#current-image-tags) |
 | `PowerShell` | `pwsh >= 7.2.16`                              |
 | `Python 3`   | see [Current image tags](#current-image-tags) |
-| `Go`         | `go >= 1.18`                                  |
+| `Go`         | `go >= 1.23.0`                                |
 
 ## Building
 

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -87,7 +87,7 @@ RUN POWERSHELL_RELEASE=$(curl -X GET -fSsIL "https://aka.ms/powershell-release?t
   && chmod +x /opt/microsoft/powershell/pwsh
 
 # Prepare Go distribution
-ARG GO_VERSION="1.21.13"
+ARG GO_VERSION="1.23.0"
 RUN curl -fSsL "https://golang.org/dl/go${GO_VERSION}.linux-${TARGETPLATFORM#linux/}.tar.gz" -o /tmp/go.tar.gz          \
   && mkdir -p /opt/golang/go                                                                                            \
   && tar -xzf /tmp/go.tar.gz -C /opt/golang/go --strip-components=1


### PR DESCRIPTION
Reroll of #14 that was meant to do this. Reasoning copied over:

Our jsii go builds are now failing with:

```
invalid go version '1.23.0': must match format 1.23
```

There are 2 things going on:

  - Go has started using 3 component version numbers, and go 1.21.0 is the first one to understand that (old versions will complain 3 components is not allowed).
   - Second, our dependency x/tools has started requiring 1.23.0.

1.22 has been end of life for 4 months (and we used to be on 1.18). It seems alright to move to the lowest supported version.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
