### PR TITLE
fix: image building breaks due to invalid maven version

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -52,7 +52,7 @@ RUN echo "deb http://deb.debian.org/debian ${DEBIAN_VERSION}-backports main"    
 SHELL ["/bin/zsh", "-c"]
 
 # Prepare maven binary distribution
-ARG M2_VERSION="3.9.10"
+ARG M2_VERSION="3.9.11"
 ENV M2_DISTRO="https://downloads.apache.org/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                             \


### PR DESCRIPTION
Looks like the [apache index](https://downloads.apache.org/maven/maven-3/) was updated to only include `3.9.11`:

<img width="517" height="206" alt="Screenshot 2025-07-24 at 9 11 40 AM" src="https://github.com/user-attachments/assets/99880dc5-62f8-453c-ac4e-f91f237bd33f" />

I'm not sure yet what the long term solution here would be, we either:

1. Find a different index that contains older versions as well.
2. Bump the maven version when the index changes.
3. Discover the latest version during build.

For now, this should fix our release.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
