### PR TITLE
fix(ci): add retry mechanism to docker build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,20 +118,26 @@ jobs:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1
       - name: Build Image
-        working-directory: superchain
-        run: |-
-          docker buildx build                                                   \
-            --quiet                                                             \
-            --builder ${{ steps.buildx.outputs.name }}                          \
-            --platform linux/amd64,linux/arm64                                  \
-            --target superchain                                                 \
-            --pull                                                              \
-            --build-arg BUILD_TIMESTAMP="${{ steps.build-time.outputs.value }}" \
-            --build-arg COMMIT_ID='${{ github.sha }}'                           \
-            --build-arg DEBIAN_VERSION=${{ matrix.debian }}                     \
-            --build-arg NODE_MAJOR_VERSION=${{ matrix.node }}                   \
-            -f Dockerfile                                                       \
-            .
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          polling_interval_seconds: 30
+          retry_on: error
+          command: |
+            cd superchain
+            docker buildx build                                                   \
+              --quiet                                                             \
+              --builder ${{ steps.buildx.outputs.name }}                          \
+              --platform linux/amd64,linux/arm64                                  \
+              --target superchain                                                 \
+              --pull                                                              \
+              --build-arg BUILD_TIMESTAMP="${{ steps.build-time.outputs.value }}" \
+              --build-arg COMMIT_ID='${{ github.sha }}'                           \
+              --build-arg DEBIAN_VERSION=${{ matrix.debian }}                     \
+              --build-arg NODE_MAJOR_VERSION=${{ matrix.node }}                   \
+              -f Dockerfile                                                       \
+              .
 
       - name: Test Image
         working-directory: superchain


### PR DESCRIPTION
This change wraps the docker buildx build step with a retry mechanism to improve build reliability. Multi-platform Docker builds can occasionally fail due to transient network issues, registry timeouts, or resource constraints. The retry action automatically attempts the build up to 3 times with a 45-minute timeout per attempt, reducing the need for manual re-runs when temporary failures occur.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
