### PR TITLE
fix: bump Maven from 3.9.12 to 3.9.14

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update                                                              
 SHELL ["/bin/zsh", "-c"]
 
 # Prepare maven binary distribution
-ARG M2_VERSION="3.9.12"
+ARG M2_VERSION="3.9.14"
 ENV M2_DISTRO="https://downloads.apache.org/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                             \


### PR DESCRIPTION
Maven 3.9.12 has been removed from `downloads.apache.org` (returns HTTP 404). This has been breaking **all** Docker Images CI runs since ~March 9, including weekly preview builds and PR #46.

**Change:** `superchain/Dockerfile` line 52: `M2_VERSION` `3.9.12` → `3.9.14`

Once this merges, PR #46 (`nick-fields/retry` v3→v4) should be re-run and will pass.