### PR TITLE
chore: route workflow event context through env vars instead of inline

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -20,6 +20,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - run: gh pr review --approve ${{ github.event.pull_request.number }} -R ${{ github.repository }}
+      - run: gh pr review --approve "$PR_NUMBER" -R "$REPO"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -24,9 +24,12 @@ jobs:
       - name: Manage regression label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-            gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+          if [ "$IS_REGRESSION" == "true" ]; then
+            gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$REPO"
           else
-            gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+            gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$REPO"
           fi


### PR DESCRIPTION
Referencing event context inline in a `run:` block substitutes the raw value into the script text, where the shell then interprets it as code. Routing values through `env:` passes them to the script as data instead, so their contents are never parsed as part of the command.




---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
