### PR TITLE
feat: add Node 26, drop Node 18, default to Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
           - "bookworm" # 12
         node: ["20", "22", "24"] # STOP! Before changing anything here, read our maintenance policy in the README
         include:
+          # We only add new Node versions to the latest Debian release
+          - debian: "trixie" # 13
+            node: "26"
           # We publish bullseye only with Node 20 & 22
           - debian: "bullseye" # 11
             node: "20"
@@ -36,7 +39,7 @@ jobs:
             node: "22"
     env:
       # Node version whose images will be aliased without the -nodeXX segment
-      DEFAULT_NODE_MAJOR_VERSION: 22
+      DEFAULT_NODE_MAJOR_VERSION: 24
     steps:
       - name: Check out
         uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ public.ecr.aws/jsii/superchain:<image-tag>
 
 | Image tag                | Debian          | Node | Python |
 | ------------------------ | --------------- | ---- | ------ |
-| `1-trixie-slim`          | `13` `trixie`   | `22` | `3.13` |
+| `1-trixie-slim`          | `13` `trixie`   | `24` | `3.13` |
 | `1-trixie-slim-node20`   | `13` `trixie`   | `20` | `3.13` |
 | `1-trixie-slim-node22`   | `13` `trixie`   | `22` | `3.13` |
 | `1-trixie-slim-node24`   | `13` `trixie`   | `24` | `3.13` |
-| `1-bookworm-slim`        | `12` `bookworm` | `22` | `3.11` |
-| `1-bookworm-slim-node18` | `12` `bookworm` | `18` | `3.11` |
+| `1-trixie-slim-node26`   | `13` `trixie`   | `26` | `3.13` |
+| `1-bookworm-slim`        | `12` `bookworm` | `24` | `3.11` |
 | `1-bookworm-slim-node20` | `12` `bookworm` | `20` | `3.11` |
 | `1-bookworm-slim-node22` | `12` `bookworm` | `22` | `3.11` |
 | `1-bookworm-slim-node24` | `12` `bookworm` | `24` | `3.11` |
@@ -70,6 +70,7 @@ We publish images variants for stable Node versions supported by the [AWS CDK](h
 Usually this means all even Node versions until six month after their EOL.
 We will only add new Node variants to the latest Debian release.
 We include the npm version that ships with the version of Node.
+Tags without an explicit `-nodeXX` segment use the current [Active LTS](https://nodejs.org/en/about/previous-releases) version of Node.
 
 ### Python
 
@@ -155,10 +156,10 @@ software contained within.
 For more information, refer to the `/NOTICE` file that is present in the Docker
 image.
 
-# FAQ
+## FAQ
 
 Q: The docker build is failing because it cannot access `proxy.golang.org`, how do I fix this?
 A: By default, Go attempts to use a module proxy, which caches modules to accelerate downloads. However, some network configurations block this proxy. Run `go env -w GOPROXY=direct` to download from source.
 
 Q: During docker image build, why do I see a warning like: "WARNING: Maven ${M2_VERSION} not found on downloads mirror, falling back to archive.apache.org"?
-A: This indicates that `M2_VERSION` has fallen behind the latest version of Maven. Update `M2_VERSION` to the latest version to address this. We first attempt to download the Maven version matching `M2_VERSION` from the regular distro: https://downloads.apache.org/maven/maven-3. However, when new versions are released, older versions are removed from that distro. We emit this warning and fall back to the archive link: https://archive.apache.org/dist/maven/maven-3.
+A: This indicates that `M2_VERSION` has fallen behind the latest version of Maven. Update `M2_VERSION` to the latest version to address this. We first attempt to download the Maven version matching `M2_VERSION` from the regular distro: <https://downloads.apache.org/maven/maven-3>. However, when new versions are released, older versions are removed from that distro. We emit this warning and fall back to the archive link: <https://archive.apache.org/dist/maven/maven-3>.

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -247,7 +247,7 @@ COPY --from=bindist /opt/golang/go ${GOROOT}
 # Install Node (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
 # (Put this as late as possible in the Dockerfile so we get to reuse the layer cache
 # for most of the multiple builds).
-ARG NODE_MAJOR_VERSION="20"
+ARG NODE_MAJOR_VERSION="24"
 COPY gpg/nodesource.asc /etc/apt/keyrings/nodesource.asc
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x nodistro main"                                    \
   > /etc/apt/sources.list.d/nodesource.list                                                                             \


### PR DESCRIPTION
Node 18 reached end of life and is no longer supported, while Node 26 is now available and needs image variants so jsii projects can build against it. This change also brings the default (unqualified) image tags in line with the current Node Active LTS.

Node 26 variants are added for trixie only, because our maintenance policy adds new Node variants exclusively to the latest Debian release. The `1-bookworm-slim-node18` tag is removed from the README; it was already absent from the build matrix, so this is purely a documentation cleanup of a stale entry.

The default Node version for unqualified tags moves from 22 to 24, since Node 24 has been the Active LTS since October 2025. To make this decision reproducible in the future, the README support policy now states that unqualified tags always point to the current Active LTS. The Dockerfile's `NODE_MAJOR_VERSION` build-arg default is aligned to 24 as well, so local builds without explicit arguments match the published default images.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
